### PR TITLE
fix edge reconstruction loss

### DIFF
--- a/utils/losses.py
+++ b/utils/losses.py
@@ -37,9 +37,9 @@ def reconstruction_loss(predicted, real, want_absolute_loss=True, want_in_mm=Fal
 def wing_reconstruction_loss(predicted, real):
     pass
 
-def edge_reconstruction_loss(predicted, real, num_vertices, mesh_f, want_absolute_loss=True):
-    from tfbody.mesh.utils import get_vertices_per_edge
-    vpe = get_vertices_per_edge(num_vertices, mesh_f)
+def edge_reconstruction_loss(predicted, real, mesh_f, want_absolute_loss=True):
+    from psbody.mesh.topology import connectivity
+    vpe = connectivity.get_vertices_per_edge(mesh_f)
     edges_for = lambda x: tf.gather(x, vpe[:, 0], axis=1) - tf.gather(x, vpe[:, 1], axis=1)
     if want_absolute_loss:
         return tf.reduce_mean(tf.reduce_sum(tf.abs(tf.subtract(edges_for(predicted), edges_for(real))), axis=2))


### PR DESCRIPTION
This commit fixes the issue #119 of importing tfbody.mesh.utils in edge_reconstruction_loss.

**Without edge reconstruction loss**

https://github.com/TimoBolkart/voca/assets/57063370/3e7b8144-631d-43fb-a005-65899a09eda1

**Edge reconstruction loss**

https://github.com/TimoBolkart/voca/assets/57063370/b57963ac-1e70-406f-8841-4b445cfbfb21