### PR TITLE
Change tensorflow-gpu requirement, keep tensorflow 1.15 functionality when using 2.0+

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ ipython
 matplotlib
 trimesh
 pyrender
-
+importlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ chumpy
 opencv-python
 resampy
 python-speech-features
-tensorflow-gpu==1.15.2
+tensorflow
 scikit-learn
 image
 ipython

--- a/utils/audio_handler.py
+++ b/utils/audio_handler.py
@@ -18,10 +18,15 @@ For comments or questions, please email us at voca@tue.mpg.de
 import re
 import copy
 import resampy
+import importlib
 import numpy as np
 import tensorflow as tf
 from python_speech_features import mfcc
 
+
+if importlib.metadata.version(tf.__name__).split(".")[0] == "2":
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
 
 def interpolate_features(features, input_rate, output_rate, output_len=None):
     num_features = features.shape[1]

--- a/utils/audio_handler.py
+++ b/utils/audio_handler.py
@@ -20,13 +20,13 @@ import copy
 import resampy
 import importlib
 import numpy as np
-import tensorflow as tf
 from python_speech_features import mfcc
 
-
-if importlib.metadata.version(tf.__name__).split(".")[0] == "2":
+if importlib.metadata.version("tensorflow").split(".")[0] == "2":
     import tensorflow.compat.v1 as tf
     tf.disable_v2_behavior()
+else:
+    import tensorflow as tf
 
 def interpolate_features(features, input_rate, output_rate, output_len=None):
     num_features = features.shape[1]

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -20,6 +20,7 @@ import os
 import cv2
 import scipy
 import tempfile
+import importlib
 import numpy as np
 import tensorflow as tf
 from subprocess import call
@@ -28,6 +29,10 @@ from scipy.io import wavfile
 from psbody.mesh import Mesh
 from utils.audio_handler import  AudioHandler
 from utils.rendering import render_mesh_helper
+
+if importlib.metadata.version(tf.__name__).split(".")[0] == "2":
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
 
 def process_audio(ds_path, audio, sample_rate):
     config = {}

--- a/utils/inference.py
+++ b/utils/inference.py
@@ -22,7 +22,6 @@ import scipy
 import tempfile
 import importlib
 import numpy as np
-import tensorflow as tf
 from subprocess import call
 from scipy.io import wavfile
 
@@ -30,9 +29,11 @@ from psbody.mesh import Mesh
 from utils.audio_handler import  AudioHandler
 from utils.rendering import render_mesh_helper
 
-if importlib.metadata.version(tf.__name__).split(".")[0] == "2":
+if importlib.metadata.version("tensorflow").split(".")[0] == "2":
     import tensorflow.compat.v1 as tf
     tf.disable_v2_behavior()
+else:
+    import tensorflow as tf
 
 def process_audio(ds_path, audio, sample_rate):
     config = {}


### PR DESCRIPTION
This PR changes the `tensorflow-gpu` requirement to `tensorflow` (as `tensorflow-gpu` has been deprecated since December 2022; see [its PyPi page](https://pypi.org/project/tensorflow-gpu/)) and adds a check to keep original `tensorflow` functionality, even in version 2.0+.